### PR TITLE
2021-assignment-sklearn: Add new test cases

### DIFF
--- a/test_sklearn_questions.py
+++ b/test_sklearn_questions.py
@@ -15,15 +15,16 @@ from sklearn_questions import KNearestNeighbors
 from sklearn_questions import MonthlySplit
 
 
-def test_one_nearest_neighbor_match_sklearn():
+@pytest.mark.parametrize("k", [1, 3, 5, 7])
+def test_one_nearest_neighbor_match_sklearn(k):
     X, y = make_classification(n_samples=200, n_features=20,
                                random_state=42)
     X_train, X_test, y_train, y_test = \
         train_test_split(X, y, random_state=42)
-    knn = KNeighborsClassifier(n_neighbors=1)
+    knn = KNeighborsClassifier(n_neighbors=k)
     y_pred_sk = knn.fit(X_train, y_train).predict(X_test)
 
-    onn = KNearestNeighbors()
+    onn = KNearestNeighbors(k)
     y_pred_me = onn.fit(X_train, y_train).predict(X_test)
     assert_array_equal(y_pred_me, y_pred_sk)
 

--- a/test_sklearn_questions.py
+++ b/test_sklearn_questions.py
@@ -8,6 +8,7 @@ from numpy.testing import assert_array_equal
 
 from sklearn.utils.estimator_checks import check_estimator
 from sklearn.model_selection import train_test_split
+from sklearn.utils import shuffle
 from sklearn.datasets import make_classification
 from sklearn.neighbors import KNeighborsClassifier
 
@@ -37,8 +38,8 @@ def test_one_nearest_neighbor_check_estimator(k):
 
 
 @pytest.mark.parametrize("end_date_and_splits", [('2021-01-31',12), ('2020-12-31',11)])
-@pytest.mark.parametrize("shuffle", [True, False])
-def test_time_split(end_date_and_splits, shuffle):
+@pytest.mark.parametrize("shuffle_data", [True, False])
+def test_time_split(end_date_and_splits, shuffle_data):
 
     date = pd.date_range(start='2020-01-01', end=end_date_and_splits[0], freq='M')
     n_samples = len(date)
@@ -48,8 +49,8 @@ def test_time_split(end_date_and_splits, shuffle):
         index=date
     )
 
-    if shuffle:
-        X = X.sample(frac=1)
+    if shuffle_data:
+        X, y = shuffle(X, y, random_state=0)
 
     X_1d = X['val']
 
@@ -86,8 +87,8 @@ def test_time_split(end_date_and_splits, shuffle):
 
 
 @pytest.mark.parametrize("end_date", ['2021-01-31', '2020-12-31'])
-@pytest.mark.parametrize("shuffle", [True, False])
-def test_time_split_on_column(end_date, shuffle):
+@pytest.mark.parametrize("shuffle_data", [True, False])
+def test_time_split_on_column(end_date, shuffle_data):
 
     date = pd.date_range(
         start='2020-01-01 00:00', end=end_date, freq='D'
@@ -98,8 +99,8 @@ def test_time_split_on_column(end_date, shuffle):
         np.array([i % 2 for i in range(n_samples)])
     )
 
-    if shuffle:
-        X = X.sample(frac=1)
+    if shuffle_data:
+        X, y = shuffle(X, y, random_state=0)
 
     cv = MonthlySplit(time_col='date')
 

--- a/test_sklearn_questions.py
+++ b/test_sklearn_questions.py
@@ -111,3 +111,118 @@ def test_time_split_on_column():
     assert 'idx' not in X.columns
 
     assert n_splits == cv.get_n_splits(X, y)
+
+def test_time_split_odd():
+
+    date = pd.date_range(start='2020-01-01', end='2020-12-31', freq='M')
+    n_samples = len(date)
+    X = pd.DataFrame(range(n_samples), index=date, columns=['val'])
+    y = pd.DataFrame(
+        np.array([i % 2 for i in range(n_samples)]),
+        index=date
+    )
+    X_1d = X['val']
+
+    cv = MonthlySplit()
+    cv_repr = "MonthlySplit(time_col='index')"
+
+    # Test if the repr works without any errors
+    assert cv_repr == repr(cv)
+
+    # Test if get_n_splits works correctly
+    assert cv.get_n_splits(X, y) == 11
+
+    # Test if the cross-validator works as expected even if
+    # the data is 1d
+    np.testing.assert_equal(
+        list(cv.split(X, y)), list(cv.split(X_1d, y))
+    )
+
+    # Test that train, test indices returned are integers and
+    # data is correctly ordered
+    for train, test in cv.split(X, y):
+        assert np.asarray(train).dtype.kind == "i"
+        assert np.asarray(test).dtype.kind == "i"
+
+        X_train, X_test = X.iloc[train], X.iloc[test]
+        y_train, y_test = y.iloc[train], y.iloc[test]
+        assert X_train.index.max() < X_test.index.min()
+        assert y_train.index.max() < y_test.index.min()
+        assert X.index.equals(y.index)
+
+    with pytest.raises(ValueError, match='datetime'):
+        cv = MonthlySplit(time_col='val')
+        next(cv.split(X, y))
+
+
+def test_time_split_on_column_odd():
+
+    date = pd.date_range(
+        start='2020-01-01 00:00', end='2020-12-31 23:59', freq='D'
+    )
+    n_samples = len(date)
+    X = pd.DataFrame({'val': range(n_samples), 'date': date})
+    y = pd.DataFrame(
+        np.array([i % 2 for i in range(n_samples)])
+    )
+
+    cv = MonthlySplit(time_col='date')
+
+    # Test that train, test indices returned are integers and
+    # data is correctly ordered
+    n_splits = 0
+    last_time = None
+    for train, test in cv.split(X, y):
+
+        X_train, X_test = X.iloc[train], X.iloc[test]
+        assert X_train['date'].max() < X_test['date'].min()
+        assert X_train['date'].dt.month.nunique() == 1
+        assert X_test['date'].dt.month.nunique() == 1
+        assert X_train['date'].dt.year.nunique() == 1
+        assert X_test['date'].dt.year.nunique() == 1
+        if last_time is not None:
+            assert X_test['date'].min() > last_time
+        last_time = X_test['date'].max()
+        n_splits += 1
+
+    assert 'idx' not in X.columns
+
+    assert n_splits == cv.get_n_splits(X, y)
+
+
+def test_time_split_shuffled_data():
+
+    date = pd.date_range(
+        start='2020-01-01 00:00', end='2021-01-31 23:59', freq='D'
+    )
+    n_samples = len(date)
+    X = pd.DataFrame({'val': range(n_samples), 'date': date})
+    y = pd.DataFrame(
+        np.array([i % 2 for i in range(n_samples)])
+    )
+
+    # Shuffle the data
+    X = X.sample(frac=1)
+
+    cv = MonthlySplit(time_col='date')
+
+    # Test that train, test indices returned are integers and
+    # data is correctly ordered
+    n_splits = 0
+    last_time = None
+    for train, test in cv.split(X, y):
+
+        X_train, X_test = X.iloc[train], X.iloc[test]
+        assert X_train['date'].max() < X_test['date'].min()
+        assert X_train['date'].dt.month.nunique() == 1
+        assert X_test['date'].dt.month.nunique() == 1
+        assert X_train['date'].dt.year.nunique() == 1
+        assert X_test['date'].dt.year.nunique() == 1
+        if last_time is not None:
+            assert X_test['date'].min() > last_time
+        last_time = X_test['date'].max()
+        n_splits += 1
+
+    assert 'idx' not in X.columns
+
+    assert n_splits == cv.get_n_splits(X, y)

--- a/test_sklearn_questions.py
+++ b/test_sklearn_questions.py
@@ -106,8 +106,8 @@ def test_time_split_on_column(end_date, shuffle_data, sample_perc):
         X, y = shuffle(X, y, random_state=0)
 
     if sample_perc < 1.0:
-        sample_index = X.sample(n=int(n_samples * sample_perc),
-                                replace=False).index
+        sample_index = np.random.randint(X.shape[0],
+                                         size=int(sample_perc * X.shape[0]))
         X = X.iloc[sample_index]
         y = y.iloc[sample_index]
 

--- a/test_sklearn_questions.py
+++ b/test_sklearn_questions.py
@@ -112,7 +112,7 @@ def test_time_split_on_column():
 
     assert n_splits == cv.get_n_splits(X, y)
 
-def test_time_split_odd():
+def test_time_split_even():
 
     date = pd.date_range(start='2020-01-01', end='2020-12-31', freq='M')
     n_samples = len(date)
@@ -155,7 +155,7 @@ def test_time_split_odd():
         next(cv.split(X, y))
 
 
-def test_time_split_on_column_odd():
+def test_time_split_on_column_even():
 
     date = pd.date_range(
         start='2020-01-01 00:00', end='2020-12-31 23:59', freq='D'

--- a/test_sklearn_questions.py
+++ b/test_sklearn_questions.py
@@ -90,7 +90,8 @@ def test_time_split(end_date_and_splits, shuffle_data):
 
 @pytest.mark.parametrize("end_date", ['2021-01-31', '2020-12-31'])
 @pytest.mark.parametrize("shuffle_data", [True, False])
-def test_time_split_on_column(end_date, shuffle_data):
+@pytest.mark.parametrize("sample_perc", [0.2, 0.5, 0.8, 1.0])
+def test_time_split_on_column(end_date, shuffle_data, sample_perc):
 
     date = pd.date_range(
         start='2020-01-01 00:00', end=end_date, freq='D'
@@ -103,6 +104,12 @@ def test_time_split_on_column(end_date, shuffle_data):
 
     if shuffle_data:
         X, y = shuffle(X, y, random_state=0)
+
+    if sample_perc < 1.0:
+        sample_index = X.sample(n=int(n_samples * sample_perc),
+                                replace=False).index
+        X = X.iloc[sample_index]
+        y = y.iloc[sample_index]
 
     cv = MonthlySplit(time_col='date')
 

--- a/test_sklearn_questions.py
+++ b/test_sklearn_questions.py
@@ -42,8 +42,7 @@ def test_one_nearest_neighbor_check_estimator(k):
 @pytest.mark.parametrize("shuffle_data", [True, False])
 def test_time_split(end_date, expected_splits, shuffle_data):
 
-    date = pd.date_range(start='2020-01-01',
-                         end=end_date, freq='D')
+    date = pd.date_range(start='2020-01-01', end=end_date, freq='D')
     n_samples = len(date)
     X = pd.DataFrame(range(n_samples), index=date, columns=['val'])
     y = pd.DataFrame(
@@ -90,8 +89,7 @@ def test_time_split(end_date, expected_splits, shuffle_data):
 
 @pytest.mark.parametrize("end_date", ['2021-01-31', '2020-12-31'])
 @pytest.mark.parametrize("shuffle_data", [True, False])
-@pytest.mark.parametrize("sample_perc", [0.2, 0.5, 0.8, 1.0])
-def test_time_split_on_column(end_date, shuffle_data, sample_perc):
+def test_time_split_on_column(end_date, shuffle_data):
 
     date = pd.date_range(
         start='2020-01-01 00:00', end=end_date, freq='D'
@@ -105,11 +103,6 @@ def test_time_split_on_column(end_date, shuffle_data, sample_perc):
     if shuffle_data:
         X, y = shuffle(X, y, random_state=0)
 
-    if sample_perc < 1.0:
-        sample_index = np.random.randint(X.shape[0],
-                                         size=int(sample_perc * X.shape[0]))
-        X = X.iloc[sample_index]
-        y = y.iloc[sample_index]
 
     cv = MonthlySplit(time_col='date')
 

--- a/test_sklearn_questions.py
+++ b/test_sklearn_questions.py
@@ -37,13 +37,13 @@ def test_one_nearest_neighbor_check_estimator(k):
     check_estimator(KNearestNeighbors(n_neighbors=k))
 
 
-@pytest.mark.parametrize("end_date_and_splits",
+@pytest.mark.parametrize("end_date, expected_splits",
                          [('2021-01-31', 12), ('2020-12-31', 11)])
 @pytest.mark.parametrize("shuffle_data", [True, False])
-def test_time_split(end_date_and_splits, shuffle_data):
+def test_time_split(end_date, expected_splits, shuffle_data):
 
     date = pd.date_range(start='2020-01-01',
-                         end=end_date_and_splits[0], freq='M')
+                         end=end_date, freq='D')
     n_samples = len(date)
     X = pd.DataFrame(range(n_samples), index=date, columns=['val'])
     y = pd.DataFrame(
@@ -63,7 +63,7 @@ def test_time_split(end_date_and_splits, shuffle_data):
     assert cv_repr == repr(cv)
 
     # Test if get_n_splits works correctly
-    assert cv.get_n_splits(X, y) == end_date_and_splits[1]
+    assert cv.get_n_splits(X, y) == expected_splits
 
     # Test if the cross-validator works as expected even if
     # the data is 1d

--- a/test_sklearn_questions.py
+++ b/test_sklearn_questions.py
@@ -112,6 +112,7 @@ def test_time_split_on_column():
 
     assert n_splits == cv.get_n_splits(X, y)
 
+
 def test_time_split_even():
 
     date = pd.date_range(start='2020-01-01', end='2020-12-31', freq='M')

--- a/test_sklearn_questions.py
+++ b/test_sklearn_questions.py
@@ -37,11 +37,13 @@ def test_one_nearest_neighbor_check_estimator(k):
     check_estimator(KNearestNeighbors(n_neighbors=k))
 
 
-@pytest.mark.parametrize("end_date_and_splits", [('2021-01-31',12), ('2020-12-31',11)])
+@pytest.mark.parametrize("end_date_and_splits",
+                         [('2021-01-31', 12), ('2020-12-31', 11)])
 @pytest.mark.parametrize("shuffle_data", [True, False])
 def test_time_split(end_date_and_splits, shuffle_data):
 
-    date = pd.date_range(start='2020-01-01', end=end_date_and_splits[0], freq='M')
+    date = pd.date_range(start='2020-01-01',
+                         end=end_date_and_splits[0], freq='M')
     n_samples = len(date)
     X = pd.DataFrame(range(n_samples), index=date, columns=['val'])
     y = pd.DataFrame(

--- a/test_sklearn_questions.py
+++ b/test_sklearn_questions.py
@@ -103,7 +103,6 @@ def test_time_split_on_column(end_date, shuffle_data):
     if shuffle_data:
         X, y = shuffle(X, y, random_state=0)
 
-
     cv = MonthlySplit(time_col='date')
 
     # Test that train, test indices returned are integers and


### PR DESCRIPTION
This PR adds many news tests

- Tests with an even number of months in the dataset
- Tests with shuffled input data
- Tests with resampled data (holes in the dataset)
- Tests to actually take `n_neighbors` into considerations

They leverage `pytest.mark.parametrize` to reuse the old tests as much as possible.